### PR TITLE
Fix Vercel deployment errors by resolving prerendering issues in auth…

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { 
   Box, 
@@ -15,7 +16,8 @@ import {
   AlertDescription,
   Code,
   Link,
-  HStack
+  HStack,
+  Flex
 } from '@chakra-ui/react'
 import { FaExclamationTriangle, FaArrowLeft, FaLifeRing } from 'react-icons/fa'
 import NextLink from 'next/link'
@@ -59,11 +61,11 @@ const errorMessages: Record<string, { title: string; description: string; action
   }
 }
 
-export default function AuthErrorPage() {
+function AuthErrorPageContent() {
   const searchParams = useSearchParams()
-  const error = searchParams.get('error') || searchParams.get('message') || 'unknown_error'
-  const errorCode = searchParams.get('error_code')
-  const errorDescription = searchParams.get('error_description')
+  const error = searchParams?.get('error') || searchParams?.get('message') || 'unknown_error'
+  const errorCode = searchParams?.get('error_code')
+  const errorDescription = searchParams?.get('error_description')
 
   const errorInfo = errorMessages[error] || {
     title: 'Authentication Error',
@@ -195,5 +197,22 @@ export default function AuthErrorPage() {
         </Container>
       </Box>
     </>
+  )
+}
+
+export default function AuthErrorPage() {
+  return (
+    <Suspense fallback={
+      <Flex minH="100vh" align="center" justify="center">
+        <VStack spacing={4}>
+          <Box className="animate-spin">
+            <Icon as={FaExclamationTriangle} w={8} h={8} color="red.500" />
+          </Box>
+          <Text>Loading...</Text>
+        </VStack>
+      </Flex>
+    }>
+      <AuthErrorPageContent />
+    </Suspense>
   )
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { 
   Box, 
@@ -25,14 +25,14 @@ import { useAuth } from '@/hooks/useAuth'
 import { toast } from 'react-hot-toast'
 import Head from 'next/head'
 
-export default function LoginPage() {
+function LoginPageContent() {
   const { signInWithGoogle, isAuthenticated, loading } = useAuth()
   const [isSigningIn, setIsSigningIn] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
-  const error = searchParams.get('error')
-  const message = searchParams.get('message')
-  const next = searchParams.get('next')
+  const error = searchParams?.get('error')
+  const message = searchParams?.get('message')
+  const next = searchParams?.get('next')
 
   const bgGradient = useColorModeValue(
     'linear(to-br, blue.50, purple.50, pink.50)',
@@ -240,5 +240,22 @@ function FeatureItem({ icon, title, description }: {
         {description}
       </Text>
     </VStack>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <Flex minH="100vh" align="center" justify="center">
+        <VStack spacing={4}>
+          <Box className="animate-spin">
+            <Icon as={FaLock} w={8} h={8} color="brand.500" />
+          </Box>
+          <Text>Loading...</Text>
+        </VStack>
+      </Flex>
+    }>
+      <LoginPageContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
… pages

- Wrap auth page components in Suspense boundaries to handle useSearchParams
- Split LoginPage and AuthErrorPage into content components
- Add proper fallback loading states for client-side rendering
- Use optional chaining for searchParams to prevent build errors

Fixes prerendering errors that prevented static export on Vercel:
- /auth/login/page: /auth/login
- /auth/error/page: /auth/error

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Resolve prerendering failures in the authentication pages by splitting page content into dedicated components, guarding search parameter access, and wrapping them in Suspense with loading fallbacks

Bug Fixes:
- Fix prerendering errors preventing static export of /auth/login and /auth/error pages

Enhancements:
- Extract LoginPage and AuthErrorPage into content components for client-side rendering
- Wrap auth page components in Suspense boundaries with loading fallback UI
- Use optional chaining on searchParams to prevent build-time errors